### PR TITLE
refactor: Set side of packemenu to CLIENT for Forge and Minecraft

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -23,14 +23,14 @@ Adds the ability to change the background of the main menu, as well as edit some
     mandatory=true #mandatory
     versionRange="[35.1.36,)" #mandatory
     ordering="NONE"
-    side="BOTH"
+    side="CLIENT"
 
 [[dependencies.packmenu]]
     modId="minecraft"
     mandatory=true
     versionRange="[1.16.4,)"
     ordering="NONE"
-    side="BOTH"
+    side="CLIENT"
 
 [[dependencies.packmenu]]
     modId="placebo"


### PR DESCRIPTION
A small change in the [[dependencies.packmenu]] declaration which reflects the actual side of the mod when used. This will help ServerPackCreator identify the sideness in future upates.

For reference: Griefed/ServerPackCreator#70

Please let me know if you have any issues with this. 

Cheers,
Griefed